### PR TITLE
Add save ministry EP

### DIFF
--- a/muster-kt/README.md
+++ b/muster-kt/README.md
@@ -19,3 +19,20 @@ Some decisions made so far:
   - Use http4k with ktor
   - Use harmkrest for testing
   - Use jackson for Json :sad_panda:
+
+
+## End Points
+
+### Ministries
+
+#### Save Ministry
+
+- URI: /v1/ministry
+- Method: POST
+- Content-Type: application/json
+- Sample request:
+  - ```
+    curl -XPOST -v -H "Content-Type: application/json" \
+    -d '{"name":"My Ministry","description":"a very important ministry"}'\
+    localhost:8888/v1/ministry
+    ```

--- a/muster-kt/build.gradle
+++ b/muster-kt/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     implementation "org.http4k:http4k-resilience4j:${http4kVersion}"
     implementation "org.http4k:http4k-server-ktorcio:${http4kVersion}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.30"
+    implementation 'ch.qos.logback:logback-classic:1.2.3'
     testImplementation "org.http4k:http4k-testing-approval:${http4kVersion}"
     testImplementation "org.http4k:http4k-testing-hamkrest:${http4kVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.7.0"

--- a/muster-kt/src/main/kotlin/com/muster/kt/HelloWorld.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/HelloWorld.kt
@@ -1,0 +1,151 @@
+package com.muster.kt
+
+import com.muster.kt.formats.JacksonMessage
+import com.muster.kt.formats.jacksonMessageLens
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType.COUNT_BASED
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.http4k.client.OkHttp
+import org.http4k.core.Method.GET
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status.Companion.INTERNAL_SERVER_ERROR
+import org.http4k.core.Status.Companion.OK
+import org.http4k.core.then
+import org.http4k.core.with
+import org.http4k.filter.*
+import org.http4k.filter.DebuggingFilters.PrintRequest
+import org.http4k.filter.DebuggingFilters.PrintResponse
+import org.http4k.filter.ResilienceFilters.CircuitBreak
+import org.http4k.routing.bind
+import org.http4k.routing.routes
+import org.http4k.server.KtorCIO
+import org.http4k.server.asServer
+import java.time.Duration
+import java.util.*
+
+object HelloWorld {
+  // this is a micrometer registry used mostly for testing - substitute the correct implementation.
+  val registry = SimpleMeterRegistry()
+  val circuitBreaker = CircuitBreaker.of(
+    "circuit",
+    CircuitBreakerConfig.custom()
+      .slidingWindow(2, 2, COUNT_BASED)
+      .permittedNumberOfCallsInHalfOpenState(2)
+      .waitDurationInOpenState(Duration.ofSeconds(1))
+      .build()
+  )
+
+  val circuitBreakerEndpointResponses = ArrayDeque<Response>().apply {
+    add(Response(OK))
+    add(Response(OK))
+    add(Response(INTERNAL_SERVER_ERROR))
+  }
+
+  val app = routes(
+    "/ping" bind GET to {
+      Response(OK).body("pong")
+    },
+
+    "/formats/json/jackson" bind GET to {
+      Response(OK).with(jacksonMessageLens of JacksonMessage("Barry", "Hello there!"))
+    },
+
+    "/testing/hamkrest" bind GET to { request ->
+      Response(OK).body("Echo '${request.bodyString()}'")
+    },
+
+    "/metrics" bind GET to {
+      Response(OK).body("Example metrics route for muster-kt")
+    },
+
+    "/resilience" bind GET to {
+      circuitBreakerEndpointResponses.pop()
+    },
+
+    "/opentelemetrymetrics" bind GET to {
+      Response(OK).body("Example metrics route for muster-kt")
+    }
+  )
+
+  fun main() {
+
+    val server = PrintRequest()
+      .then(ServerFilters.MicrometerMetrics.RequestCounter(registry))
+      .then(ServerFilters.MicrometerMetrics.RequestTimer(registry))
+      .then(ServerFilters.OpenTelemetryTracing())
+      .then(ServerFilters.OpenTelemetryMetrics.RequestCounter())
+      .then(ServerFilters.OpenTelemetryMetrics.RequestTimer())
+      .then(app)
+      .asServer(KtorCIO(9000)).start()
+
+    val client = PrintResponse()
+      .then(ClientFilters.MicrometerMetrics.RequestCounter(registry))
+      .then(ClientFilters.MicrometerMetrics.RequestTimer(registry))
+      .then(ClientFilters.OpenTelemetryTracing())
+      .then(ClientFilters.OpenTelemetryMetrics.RequestCounter())
+      .then(ClientFilters.OpenTelemetryMetrics.RequestTimer())
+      .then(CircuitBreak(circuitBreaker, isError = { r: Response -> !r.status.successful }))
+      .then(OkHttp())
+
+    val response = client(Request(GET, "http://localhost:9000/ping"))
+
+    println(response.bodyString())
+
+    // Example usage of metrics
+    // make some calls
+    repeat(10) {
+      app(Request(GET, "/metrics"))
+      client(Request(GET, "https://http4k.org"))
+    }
+
+    // see some results
+    registry.forEachMeter { println("${it.id} ${it.measure().joinToString(",")}") }
+    // Resilience4j
+    // Example of circuit breaker
+    println(
+      "Result: " + client(
+        Request(
+          GET,
+          "http://localhost:9000/resilience"
+        )
+      ).status + " Circuit is: " + circuitBreaker.state
+    )
+    println(
+      "Result: " + client(
+        Request(
+          GET,
+          "http://localhost:9000/resilience"
+        )
+      ).status + " Circuit is: " + circuitBreaker.state
+    )
+
+    Thread.sleep(1100) // wait for reset
+
+    println(
+      "Result: " + client(
+        Request(
+          GET,
+          "http://localhost:9000/resilience"
+        )
+      ).status + " Circuit is: " + circuitBreaker.state
+    )
+    println(
+      "Result: " + client(
+        Request(
+          GET,
+          "http://localhost:9000/resilience"
+        )
+      ).status + " Circuit is: " + circuitBreaker.state
+    )
+    // Example usage of metrics
+    // make some calls
+    repeat(10) {
+      app(Request(GET, "/opentelemetrymetrics"))
+      client(Request(GET, "https://http4k.org"))
+    }
+
+    println("Server started on " + server.port())
+  }
+}

--- a/muster-kt/src/main/kotlin/com/muster/kt/Muster.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/Muster.kt
@@ -24,6 +24,7 @@ fun main() {
     .then(ServerFilters.OpenTelemetryMetrics.RequestCounter())
     .then(ServerFilters.OpenTelemetryMetrics.RequestTimer())
     .then(app)
-    .asServer(KtorCIO(8080))
+    .asServer(KtorCIO(8888))
     .start()
+    .block()
 }

--- a/muster-kt/src/main/kotlin/com/muster/kt/Muster.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/Muster.kt
@@ -6,8 +6,6 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType.COUNT_BASED
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import java.time.Duration
-import java.util.*
 import org.http4k.client.OkHttp
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
@@ -16,33 +14,32 @@ import org.http4k.core.Status.Companion.INTERNAL_SERVER_ERROR
 import org.http4k.core.Status.Companion.OK
 import org.http4k.core.then
 import org.http4k.core.with
-import org.http4k.filter.ClientFilters
+import org.http4k.filter.*
 import org.http4k.filter.DebuggingFilters.PrintRequest
 import org.http4k.filter.DebuggingFilters.PrintResponse
-import org.http4k.filter.MicrometerMetrics
-import org.http4k.filter.OpenTelemetryMetrics
-import org.http4k.filter.OpenTelemetryTracing
 import org.http4k.filter.ResilienceFilters.CircuitBreak
-import org.http4k.filter.ServerFilters
 import org.http4k.routing.bind
 import org.http4k.routing.routes
 import org.http4k.server.KtorCIO
 import org.http4k.server.asServer
+import java.time.Duration
+import java.util.*
 
 // this is a micrometer registry used mostly for testing - substitute the correct implementation.
 val registry = SimpleMeterRegistry()
-val circuitBreaker = CircuitBreaker.of("circuit",
-        CircuitBreakerConfig.custom()
-                .slidingWindow(2, 2, COUNT_BASED)
-                .permittedNumberOfCallsInHalfOpenState(2)
-                .waitDurationInOpenState(Duration.ofSeconds(1))
-                .build()
+val circuitBreaker = CircuitBreaker.of(
+  "circuit",
+  CircuitBreakerConfig.custom()
+    .slidingWindow(2, 2, COUNT_BASED)
+    .permittedNumberOfCallsInHalfOpenState(2)
+    .waitDurationInOpenState(Duration.ofSeconds(1))
+    .build()
 )
 
 val circuitBreakerEndpointResponses = ArrayDeque<Response>().apply {
-    add(Response(OK))
-    add(Response(OK))
-    add(Response(INTERNAL_SERVER_ERROR))
+  add(Response(OK))
+  add(Response(OK))
+  add(Response(INTERNAL_SERVER_ERROR))
 }
 
 val app = routes(
@@ -50,75 +47,103 @@ val app = routes(
         Response(OK).body("pong")
     },
 
-    "/formats/json/jackson" bind GET to {
-        Response(OK).with(jacksonMessageLens of JacksonMessage("Barry", "Hello there!"))
-    },
+  "/formats/json/jackson" bind GET to {
+    Response(OK).with(jacksonMessageLens of JacksonMessage("Barry", "Hello there!"))
+  },
 
-    "/testing/hamkrest" bind GET to {request ->
-        Response(OK).body("Echo '${request.bodyString()}'")
-    },
+  "/testing/hamkrest" bind GET to { request ->
+    Response(OK).body("Echo '${request.bodyString()}'")
+  },
 
-    "/metrics" bind GET to {
-        Response(OK).body("Example metrics route for muster-kt")
-    },
+  "/metrics" bind GET to {
+    Response(OK).body("Example metrics route for muster-kt")
+  },
 
-    "/resilience" bind GET to {
-        circuitBreakerEndpointResponses.pop()
-    },
+  "/resilience" bind GET to {
+    circuitBreakerEndpointResponses.pop()
+  },
 
-    "/opentelemetrymetrics" bind GET to {
-        Response(OK).body("Example metrics route for muster-kt")
-    }
+  "/opentelemetrymetrics" bind GET to {
+    Response(OK).body("Example metrics route for muster-kt")
+  }
 )
 
 fun main() {
 
-    val server = PrintRequest()
-            .then(ServerFilters.MicrometerMetrics.RequestCounter(registry))
-            .then(ServerFilters.MicrometerMetrics.RequestTimer(registry))
-            .then(ServerFilters.OpenTelemetryTracing())
-            .then(ServerFilters.OpenTelemetryMetrics.RequestCounter())
-            .then(ServerFilters.OpenTelemetryMetrics.RequestTimer())
-        .then(app)
-        .asServer(KtorCIO(9000)).start()
+  val server = PrintRequest()
+    .then(ServerFilters.MicrometerMetrics.RequestCounter(registry))
+    .then(ServerFilters.MicrometerMetrics.RequestTimer(registry))
+    .then(ServerFilters.OpenTelemetryTracing())
+    .then(ServerFilters.OpenTelemetryMetrics.RequestCounter())
+    .then(ServerFilters.OpenTelemetryMetrics.RequestTimer())
+    .then(app)
+    .asServer(KtorCIO(9000)).start()
 
-    val client = PrintResponse()
-            .then(ClientFilters.MicrometerMetrics.RequestCounter(registry))
-            .then(ClientFilters.MicrometerMetrics.RequestTimer(registry))
-            .then(ClientFilters.OpenTelemetryTracing())
-            .then(ClientFilters.OpenTelemetryMetrics.RequestCounter())
-            .then(ClientFilters.OpenTelemetryMetrics.RequestTimer())
-            .then(CircuitBreak(circuitBreaker, isError = { r: Response -> !r.status.successful } ))
-        .then(OkHttp())
+  val client = PrintResponse()
+    .then(ClientFilters.MicrometerMetrics.RequestCounter(registry))
+    .then(ClientFilters.MicrometerMetrics.RequestTimer(registry))
+    .then(ClientFilters.OpenTelemetryTracing())
+    .then(ClientFilters.OpenTelemetryMetrics.RequestCounter())
+    .then(ClientFilters.OpenTelemetryMetrics.RequestTimer())
+    .then(CircuitBreak(circuitBreaker, isError = { r: Response -> !r.status.successful }))
+    .then(OkHttp())
 
-    val response = client(Request(GET, "http://localhost:9000/ping"))
+  val response = client(Request(GET, "http://localhost:9000/ping"))
 
-    println(response.bodyString())
+  println(response.bodyString())
 
-    // Example usage of metrics
-    // make some calls
-    repeat(10) {
-        app(Request(GET, "/metrics"))
-        client(Request(GET, "https://http4k.org"))
-    }
-    
-    // see some results
-    registry.forEachMeter { println("${it.id} ${it.measure().joinToString(",")}") }
-    // Resilience4j
-    // Example of circuit breaker
-    println("Result: " + client(Request(GET, "http://localhost:9000/resilience")).status + " Circuit is: " + circuitBreaker.state)
-    println("Result: " + client(Request(GET, "http://localhost:9000/resilience")).status + " Circuit is: " + circuitBreaker.state)
-    
-    Thread.sleep(1100) // wait for reset
-    
-    println("Result: " + client(Request(GET, "http://localhost:9000/resilience")).status + " Circuit is: " + circuitBreaker.state)
-    println("Result: " + client(Request(GET, "http://localhost:9000/resilience")).status + " Circuit is: " + circuitBreaker.state)
-    // Example usage of metrics
-    // make some calls
-    repeat(10) {
-        app(Request(GET, "/opentelemetrymetrics"))
-        client(Request(GET, "https://http4k.org"))
-    }
+  // Example usage of metrics
+  // make some calls
+  repeat(10) {
+    app(Request(GET, "/metrics"))
+    client(Request(GET, "https://http4k.org"))
+  }
 
-    println("Server started on " + server.port())
+  // see some results
+  registry.forEachMeter { println("${it.id} ${it.measure().joinToString(",")}") }
+  // Resilience4j
+  // Example of circuit breaker
+  println(
+    "Result: " + client(
+      Request(
+        GET,
+        "http://localhost:9000/resilience"
+      )
+    ).status + " Circuit is: " + circuitBreaker.state
+  )
+  println(
+    "Result: " + client(
+      Request(
+        GET,
+        "http://localhost:9000/resilience"
+      )
+    ).status + " Circuit is: " + circuitBreaker.state
+  )
+
+  Thread.sleep(1100) // wait for reset
+
+  println(
+    "Result: " + client(
+      Request(
+        GET,
+        "http://localhost:9000/resilience"
+      )
+    ).status + " Circuit is: " + circuitBreaker.state
+  )
+  println(
+    "Result: " + client(
+      Request(
+        GET,
+        "http://localhost:9000/resilience"
+      )
+    ).status + " Circuit is: " + circuitBreaker.state
+  )
+  // Example usage of metrics
+  // make some calls
+  repeat(10) {
+    app(Request(GET, "/opentelemetrymetrics"))
+    client(Request(GET, "https://http4k.org"))
+  }
+
+  println("Server started on " + server.port())
 }

--- a/muster-kt/src/main/kotlin/com/muster/kt/Muster.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/Muster.kt
@@ -24,6 +24,6 @@ fun main() {
     .then(ServerFilters.OpenTelemetryMetrics.RequestCounter())
     .then(ServerFilters.OpenTelemetryMetrics.RequestTimer())
     .then(app)
-    .asServer(KtorCIO(9000))
+    .asServer(KtorCIO(8080))
     .start()
 }

--- a/muster-kt/src/main/kotlin/com/muster/kt/Muster.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/Muster.kt
@@ -1,149 +1,29 @@
 package com.muster.kt
 
-import com.muster.kt.formats.JacksonMessage
-import com.muster.kt.formats.jacksonMessageLens
-import io.github.resilience4j.circuitbreaker.CircuitBreaker
-import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
-import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType.COUNT_BASED
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import org.http4k.client.OkHttp
-import org.http4k.core.Method.GET
-import org.http4k.core.Request
-import org.http4k.core.Response
-import org.http4k.core.Status.Companion.INTERNAL_SERVER_ERROR
-import org.http4k.core.Status.Companion.OK
 import org.http4k.core.then
-import org.http4k.core.with
-import org.http4k.filter.*
 import org.http4k.filter.DebuggingFilters.PrintRequest
-import org.http4k.filter.DebuggingFilters.PrintResponse
-import org.http4k.filter.ResilienceFilters.CircuitBreak
-import org.http4k.routing.bind
-import org.http4k.routing.routes
+import org.http4k.filter.MicrometerMetrics
+import org.http4k.filter.OpenTelemetryMetrics
+import org.http4k.filter.OpenTelemetryTracing
+import org.http4k.filter.ServerFilters
 import org.http4k.server.KtorCIO
 import org.http4k.server.asServer
-import java.time.Duration
-import java.util.*
 
 // this is a micrometer registry used mostly for testing - substitute the correct implementation.
 val registry = SimpleMeterRegistry()
-val circuitBreaker = CircuitBreaker.of(
-  "circuit",
-  CircuitBreakerConfig.custom()
-    .slidingWindow(2, 2, COUNT_BASED)
-    .permittedNumberOfCallsInHalfOpenState(2)
-    .waitDurationInOpenState(Duration.ofSeconds(1))
-    .build()
-)
 
-val circuitBreakerEndpointResponses = ArrayDeque<Response>().apply {
-  add(Response(OK))
-  add(Response(OK))
-  add(Response(INTERNAL_SERVER_ERROR))
-}
-
-val app = routes(
-    "/ping" bind GET to {
-        Response(OK).body("pong")
-    },
-
-  "/formats/json/jackson" bind GET to {
-    Response(OK).with(jacksonMessageLens of JacksonMessage("Barry", "Hello there!"))
-  },
-
-  "/testing/hamkrest" bind GET to { request ->
-    Response(OK).body("Echo '${request.bodyString()}'")
-  },
-
-  "/metrics" bind GET to {
-    Response(OK).body("Example metrics route for muster-kt")
-  },
-
-  "/resilience" bind GET to {
-    circuitBreakerEndpointResponses.pop()
-  },
-
-  "/opentelemetrymetrics" bind GET to {
-    Response(OK).body("Example metrics route for muster-kt")
-  }
-)
+val app = Runtime.application
 
 fun main() {
 
-  val server = PrintRequest()
+  PrintRequest()
     .then(ServerFilters.MicrometerMetrics.RequestCounter(registry))
     .then(ServerFilters.MicrometerMetrics.RequestTimer(registry))
     .then(ServerFilters.OpenTelemetryTracing())
     .then(ServerFilters.OpenTelemetryMetrics.RequestCounter())
     .then(ServerFilters.OpenTelemetryMetrics.RequestTimer())
     .then(app)
-    .asServer(KtorCIO(9000)).start()
-
-  val client = PrintResponse()
-    .then(ClientFilters.MicrometerMetrics.RequestCounter(registry))
-    .then(ClientFilters.MicrometerMetrics.RequestTimer(registry))
-    .then(ClientFilters.OpenTelemetryTracing())
-    .then(ClientFilters.OpenTelemetryMetrics.RequestCounter())
-    .then(ClientFilters.OpenTelemetryMetrics.RequestTimer())
-    .then(CircuitBreak(circuitBreaker, isError = { r: Response -> !r.status.successful }))
-    .then(OkHttp())
-
-  val response = client(Request(GET, "http://localhost:9000/ping"))
-
-  println(response.bodyString())
-
-  // Example usage of metrics
-  // make some calls
-  repeat(10) {
-    app(Request(GET, "/metrics"))
-    client(Request(GET, "https://http4k.org"))
-  }
-
-  // see some results
-  registry.forEachMeter { println("${it.id} ${it.measure().joinToString(",")}") }
-  // Resilience4j
-  // Example of circuit breaker
-  println(
-    "Result: " + client(
-      Request(
-        GET,
-        "http://localhost:9000/resilience"
-      )
-    ).status + " Circuit is: " + circuitBreaker.state
-  )
-  println(
-    "Result: " + client(
-      Request(
-        GET,
-        "http://localhost:9000/resilience"
-      )
-    ).status + " Circuit is: " + circuitBreaker.state
-  )
-
-  Thread.sleep(1100) // wait for reset
-
-  println(
-    "Result: " + client(
-      Request(
-        GET,
-        "http://localhost:9000/resilience"
-      )
-    ).status + " Circuit is: " + circuitBreaker.state
-  )
-  println(
-    "Result: " + client(
-      Request(
-        GET,
-        "http://localhost:9000/resilience"
-      )
-    ).status + " Circuit is: " + circuitBreaker.state
-  )
-  // Example usage of metrics
-  // make some calls
-  repeat(10) {
-    app(Request(GET, "/opentelemetrymetrics"))
-    client(Request(GET, "https://http4k.org"))
-  }
-
-  println("Server started on " + server.port())
+    .asServer(KtorCIO(9000))
+    .start()
 }

--- a/muster-kt/src/main/kotlin/com/muster/kt/Routes.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/Routes.kt
@@ -13,6 +13,6 @@ class Routes(private val handleCreateMinistry: (CreateMinistryRequest) -> Respon
   private val createMinistryLens = Body.auto<CreateMinistryRequest>().toLens()
 
   val musterApp = routes(
-    "/ministry" bind POST to { request: Request -> handleCreateMinistry(createMinistryLens(request)) },
+    "/v1/ministry" bind POST to { request: Request -> handleCreateMinistry(createMinistryLens(request)) },
   )
 }

--- a/muster-kt/src/main/kotlin/com/muster/kt/Routes.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/Routes.kt
@@ -1,6 +1,6 @@
 package com.muster.kt
 
-import com.muster.kt.endpoints.CreateMinistryRequest
+import com.muster.kt.endpoints.ministry.saveministry.CreateMinistryRequest
 import org.http4k.core.Body
 import org.http4k.core.Method.POST
 import org.http4k.core.Request

--- a/muster-kt/src/main/kotlin/com/muster/kt/Routes.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/Routes.kt
@@ -10,11 +10,9 @@ import org.http4k.routing.bind
 import org.http4k.routing.routes
 
 class Routes(private val handleCreateMinistry: (CreateMinistryRequest) -> Response) {
-
   private val createMinistryLens = Body.auto<CreateMinistryRequest>().toLens()
 
   val musterApp = routes(
-    "/" bind POST to { request: Request -> handleCreateMinistry(createMinistryLens(request)) },
+    "/ministry" bind POST to { request: Request -> handleCreateMinistry(createMinistryLens(request)) },
   )
-
 }

--- a/muster-kt/src/main/kotlin/com/muster/kt/Routes.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/Routes.kt
@@ -1,0 +1,20 @@
+package com.muster.kt
+
+import com.muster.kt.endpoints.CreateMinistryRequest
+import org.http4k.core.Body
+import org.http4k.core.Method.POST
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.format.Jackson.auto
+import org.http4k.routing.bind
+import org.http4k.routing.routes
+
+class Routes(private val handleCreateMinistry: (CreateMinistryRequest) -> Response) {
+
+  private val createMinistryLens = Body.auto<CreateMinistryRequest>().toLens()
+
+  val musterApp = routes(
+    "/" bind POST to { request: Request -> handleCreateMinistry(createMinistryLens(request)) },
+  )
+
+}

--- a/muster-kt/src/main/kotlin/com/muster/kt/Runtime.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/Runtime.kt
@@ -1,0 +1,20 @@
+package com.muster.kt
+
+import com.muster.kt.endpoints.MinistryControllerImpl
+import com.muster.kt.endpoints.MinistryService
+import com.muster.kt.model.Ministry
+import java.util.*
+
+object Runtime {
+  private object MinistryServiceRuntime {
+    val ministrService = MinistryService(
+      getUUID = { Optional.ofNullable(UUID.randomUUID()) }
+    )
+    val ministryController = MinistryControllerImpl(
+      saveMinistry = { cmr -> ministrService.saveMinistry(cmr) }
+    )
+  }
+  val application = Routes(
+    handleCreateMinistry = { request -> MinistryServiceRuntime.ministryController.handleSaveMinistry(request) }
+  ).musterApp
+}

--- a/muster-kt/src/main/kotlin/com/muster/kt/Runtime.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/Runtime.kt
@@ -1,8 +1,7 @@
 package com.muster.kt
 
-import com.muster.kt.endpoints.MinistryControllerImpl
-import com.muster.kt.endpoints.MinistryService
-import com.muster.kt.model.Ministry
+import com.muster.kt.endpoints.ministry.saveministry.MinistryControllerImpl
+import com.muster.kt.endpoints.ministry.saveministry.MinistryService
 import java.util.*
 
 object Runtime {

--- a/muster-kt/src/main/kotlin/com/muster/kt/endpoints/MinistryController.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/endpoints/MinistryController.kt
@@ -10,21 +10,14 @@ fun interface MinistryController {
 }
 
 class MinistryControllerImpl(
-  private val getUUID: () -> UUID,
-  private val saveMinistry: (Ministry) -> Optional<UUID>
+  private val saveMinistry: (CreateMinistryRequest) -> Optional<UUID>
 ) : MinistryController {
-  override fun handleSaveMinistry(createMinistryRequest: CreateMinistryRequest): Response {
-    val result = saveMinistry(
-      Ministry(
-        id = getUUID(),
-        name = createMinistryRequest.name,
-        description = createMinistryRequest.description
-      )
-    )
 
-    return result.map { uuid ->
+  override fun handleSaveMinistry(createMinistryRequest: CreateMinistryRequest): Response {
+    val ministry = saveMinistry(createMinistryRequest)
+    return ministry.map { uuid ->
       Response(Status.OK).body(uuid.toString())
     }.orElse(Response(Status.INTERNAL_SERVER_ERROR).body("unable to fulfil request"))
   }
-}
 
+}

--- a/muster-kt/src/main/kotlin/com/muster/kt/endpoints/MinistryController.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/endpoints/MinistryController.kt
@@ -1,24 +1,30 @@
 package com.muster.kt.endpoints
 
 import com.muster.kt.model.Ministry
+import org.http4k.core.Response
+import org.http4k.core.Status
 import java.util.*
 
 fun interface MinistryController {
-  fun handleSaveMinistry(ministry: CreateMinistryRequest): Optional<UUID>
+  fun handleSaveMinistry(ministry: CreateMinistryRequest): Response
 }
 
 class MinistryControllerImpl(
   private val getUUID: () -> UUID,
   private val saveMinistry: (Ministry) -> Optional<UUID>
 ) : MinistryController {
-  override fun handleSaveMinistry(createMinistryRequest: CreateMinistryRequest): Optional<UUID> {
-    return saveMinistry(
+  override fun handleSaveMinistry(createMinistryRequest: CreateMinistryRequest): Response {
+    val result = saveMinistry(
       Ministry(
         id = getUUID(),
         name = createMinistryRequest.name,
         description = createMinistryRequest.description
       )
     )
+
+    return result.map { uuid ->
+      Response(Status.OK).body(uuid.toString())
+    }.orElse(Response(Status.INTERNAL_SERVER_ERROR).body("unable to fulfil request"))
   }
 }
 

--- a/muster-kt/src/main/kotlin/com/muster/kt/endpoints/MinistryService.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/endpoints/MinistryService.kt
@@ -1,0 +1,16 @@
+package com.muster.kt.endpoints
+
+import com.muster.kt.model.Ministry
+import java.util.*
+
+class MinistryService(private val getUUID: () -> Optional<UUID>) {
+  private var ministryInMemoryStore = mutableMapOf<UUID, Ministry>()
+
+  fun saveMinistry(createMinistryRequest: CreateMinistryRequest): Optional<UUID> {
+    return getUUID().map { uuid ->
+      val ministry = Ministry(uuid, createMinistryRequest.name, createMinistryRequest.description)
+      ministryInMemoryStore.put(uuid, ministry)
+      uuid
+    }
+  }
+}

--- a/muster-kt/src/main/kotlin/com/muster/kt/endpoints/ministry/saveministry/CreateMinistryRequest.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/endpoints/ministry/saveministry/CreateMinistryRequest.kt
@@ -1,3 +1,3 @@
-package com.muster.kt.endpoints
+package com.muster.kt.endpoints.ministry.saveministry
 
 data class CreateMinistryRequest(val name: String, val description: String)

--- a/muster-kt/src/main/kotlin/com/muster/kt/endpoints/ministry/saveministry/MinistryController.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/endpoints/ministry/saveministry/MinistryController.kt
@@ -1,6 +1,5 @@
-package com.muster.kt.endpoints
+package com.muster.kt.endpoints.ministry.saveministry
 
-import com.muster.kt.model.Ministry
 import org.http4k.core.Response
 import org.http4k.core.Status
 import java.util.*

--- a/muster-kt/src/main/kotlin/com/muster/kt/endpoints/ministry/saveministry/MinistryController.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/endpoints/ministry/saveministry/MinistryController.kt
@@ -5,7 +5,7 @@ import org.http4k.core.Status
 import java.util.*
 
 fun interface MinistryController {
-  fun handleSaveMinistry(ministry: CreateMinistryRequest): Response
+  fun handleSaveMinistry(createMinistryRequest: CreateMinistryRequest): Response
 }
 
 class MinistryControllerImpl(

--- a/muster-kt/src/main/kotlin/com/muster/kt/endpoints/ministry/saveministry/MinistryService.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/endpoints/ministry/saveministry/MinistryService.kt
@@ -1,4 +1,4 @@
-package com.muster.kt.endpoints
+package com.muster.kt.endpoints.ministry.saveministry
 
 import com.muster.kt.model.Ministry
 import java.util.*

--- a/muster-kt/src/main/kotlin/com/muster/kt/endpoints/ministry/saveministry/MinistryService.kt
+++ b/muster-kt/src/main/kotlin/com/muster/kt/endpoints/ministry/saveministry/MinistryService.kt
@@ -4,13 +4,13 @@ import com.muster.kt.model.Ministry
 import java.util.*
 
 class MinistryService(private val getUUID: () -> Optional<UUID>) {
-  private var ministryInMemoryStore = mutableMapOf<UUID, Ministry>()
+  private val ministryInMemoryStore = mutableMapOf<UUID, Ministry>()
 
   fun saveMinistry(createMinistryRequest: CreateMinistryRequest): Optional<UUID> {
-    return getUUID().map { uuid ->
+    return getUUID().flatMap { uuid ->
       val ministry = Ministry(uuid, createMinistryRequest.name, createMinistryRequest.description)
-      ministryInMemoryStore.put(uuid, ministry)
-      uuid
+      ministryInMemoryStore[uuid] = ministry
+      Optional.ofNullable(ministryInMemoryStore[uuid]).map { m -> m.id }
     }
   }
 }

--- a/muster-kt/src/test/kotlin/com/muster/kt/HelloWorldTest.kt
+++ b/muster-kt/src/test/kotlin/com/muster/kt/HelloWorldTest.kt
@@ -17,7 +17,7 @@ import org.http4k.lens.string
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-class MusterTest {
+class HelloWorldTest {
 
     @Test
     fun `Ping test`() {

--- a/muster-kt/src/test/kotlin/com/muster/kt/HelloWorldTest.kt
+++ b/muster-kt/src/test/kotlin/com/muster/kt/HelloWorldTest.kt
@@ -17,7 +17,7 @@ import org.http4k.lens.string
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-class HelloWorldTest {
+internal class HelloWorldTest {
 
     @Test
     fun `Ping test`() {

--- a/muster-kt/src/test/kotlin/com/muster/kt/HelloWorldTest.kt
+++ b/muster-kt/src/test/kotlin/com/muster/kt/HelloWorldTest.kt
@@ -21,13 +21,13 @@ class MusterTest {
 
     @Test
     fun `Ping test`() {
-        assertEquals(app(Request(GET, "/ping")), Response(OK).body("pong"))
+        assertEquals(HelloWorld.app(Request(GET, "/ping")), Response(OK).body("pong"))
     }
     @Test
     fun `Check Hamkrest matcher for http4k work as expected`() {
         val request = Request(GET, "/testing/hamkrest?a=b").body("http4k is cool").header("my header", "a value")
     
-        val response = app(request)
+        val response = HelloWorld.app(request)
     
         // response assertions
         assertThat(response, hasStatus(OK))

--- a/muster-kt/src/test/kotlin/com/muster/kt/RoutesTest.kt
+++ b/muster-kt/src/test/kotlin/com/muster/kt/RoutesTest.kt
@@ -11,7 +11,7 @@ import org.http4k.core.Status.Companion.OK
 import org.http4k.hamkrest.hasBody
 import org.http4k.hamkrest.hasStatus
 
-class RoutesTest {
+internal class RoutesTest {
 
   private val musterApp = Routes( handleCreateMinistry = { Response(OK).body("an-uuid")}).musterApp
 

--- a/muster-kt/src/test/kotlin/com/muster/kt/RoutesTest.kt
+++ b/muster-kt/src/test/kotlin/com/muster/kt/RoutesTest.kt
@@ -23,7 +23,7 @@ internal class RoutesTest {
         "description": "bar"
       }
     """.trimIndent()
-    val response = musterApp(Request(POST, "/ministry").body(requestBody))
+    val response = musterApp(Request(POST, "/v1/ministry").body(requestBody))
     assertThat(response, hasStatus(OK).and(hasBody("an-uuid")))
   }
 }

--- a/muster-kt/src/test/kotlin/com/muster/kt/RoutesTest.kt
+++ b/muster-kt/src/test/kotlin/com/muster/kt/RoutesTest.kt
@@ -1,0 +1,29 @@
+package com.muster.kt
+
+import org.junit.jupiter.api.Test
+
+import com.natpryce.hamkrest.and
+import com.natpryce.hamkrest.assertion.assertThat
+
+import org.http4k.core.*
+import org.http4k.core.Method.POST
+import org.http4k.core.Status.Companion.OK
+import org.http4k.hamkrest.hasBody
+import org.http4k.hamkrest.hasStatus
+
+class RoutesTest {
+
+  private val musterApp = Routes( handleCreateMinistry = { Response(OK).body("an-uuid")}).musterApp
+
+  @Test
+  fun shouldCreateAMinistry() {
+    val requestBody = """
+      {
+        "name": "foo",
+        "description": "bar"
+      }
+    """.trimIndent()
+    val response = musterApp(Request(POST, "/ministry").body(requestBody))
+    assertThat(response, hasStatus(OK).and(hasBody("an-uuid")))
+  }
+}

--- a/muster-kt/src/test/kotlin/com/muster/kt/endpoints/MinistryControllerImplTest.kt
+++ b/muster-kt/src/test/kotlin/com/muster/kt/endpoints/MinistryControllerImplTest.kt
@@ -2,8 +2,10 @@ package com.muster.kt.endpoints
 
 
 import com.muster.kt.model.Ministry
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import com.natpryce.hamkrest.assertion.assertThat
+import org.http4k.core.Status
+import org.http4k.hamkrest.hasBody
+import org.http4k.hamkrest.hasStatus
 import org.junit.jupiter.api.Test
 import java.util.*
 
@@ -12,12 +14,26 @@ internal class MinistryControllerImplTest {
   private val testUUID = UUID.fromString("459a1eb6-ad8d-11eb-8529-0242ac130003")
   private val controller = MinistryControllerImpl(
     getUUID = { testUUID },
-    saveMinistry = { m: Ministry -> Optional.of(m.id)}
+    saveMinistry = { m: Ministry ->
+      if (m.name == "Foo") Optional.of(m.id) else Optional.empty()
+    }
   )
 
   @Test
   fun handleSaveMinistry_shouldSaveMinistry() {
     val cmr = CreateMinistryRequest("Foo", "Bar")
-    assertThat(controller.handleSaveMinistry(cmr), equalTo(Optional.of(testUUID)))
+    assertThat(controller.handleSaveMinistry(cmr), hasStatus(Status.OK))
+  }
+
+  @Test
+  fun handleSaveMinistry_shouldReturnBodyWithId() {
+    val cmr = CreateMinistryRequest("Foo", "Bar")
+    assertThat(controller.handleSaveMinistry(cmr), hasBody("459a1eb6-ad8d-11eb-8529-0242ac130003"))
+  }
+
+  @Test
+  fun handleSaveMinistry_shouldFailSavingWith500() {
+    val cmr = CreateMinistryRequest("Baz", "Blah")
+    assertThat(controller.handleSaveMinistry(cmr), hasStatus(Status.INTERNAL_SERVER_ERROR))
   }
 }

--- a/muster-kt/src/test/kotlin/com/muster/kt/endpoints/MinistryControllerImplTest.kt
+++ b/muster-kt/src/test/kotlin/com/muster/kt/endpoints/MinistryControllerImplTest.kt
@@ -1,6 +1,5 @@
 package com.muster.kt.endpoints
 
-
 import com.muster.kt.model.Ministry
 import com.natpryce.hamkrest.assertion.assertThat
 import org.http4k.core.Status
@@ -11,11 +10,10 @@ import java.util.*
 
 internal class MinistryControllerImplTest {
 
-  private val testUUID = UUID.fromString("459a1eb6-ad8d-11eb-8529-0242ac130003")
+  private val testUUID = Optional.of(UUID.fromString("459a1eb6-ad8d-11eb-8529-0242ac130003"))
   private val controller = MinistryControllerImpl(
-    getUUID = { testUUID },
-    saveMinistry = { m: Ministry ->
-      if (m.name == "Foo") Optional.of(m.id) else Optional.empty()
+    saveMinistry = { m: CreateMinistryRequest ->
+      if (m.name == "Foo") testUUID else Optional.empty()
     }
   )
 

--- a/muster-kt/src/test/kotlin/com/muster/kt/endpoints/MinistryServiceTest.kt
+++ b/muster-kt/src/test/kotlin/com/muster/kt/endpoints/MinistryServiceTest.kt
@@ -1,0 +1,18 @@
+package com.muster.kt.endpoints
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+import java.util.*
+
+internal class MinistryServiceTest {
+
+  private val testUUID = Optional.of(UUID.fromString("459a1eb6-ad8d-11eb-8529-0242ac130003"))
+  private val service = MinistryService(getUUID = { testUUID })
+
+  @Test
+  fun shouldSaveMinistry() {
+    val cmr = CreateMinistryRequest("Foo", "Bar")
+    assertThat(service.saveMinistry(cmr), equalTo(testUUID))
+  }
+}

--- a/muster-kt/src/test/kotlin/com/muster/kt/endpoints/ministry/saveministry/MinistryControllerImplTest.kt
+++ b/muster-kt/src/test/kotlin/com/muster/kt/endpoints/ministry/saveministry/MinistryControllerImplTest.kt
@@ -1,6 +1,5 @@
-package com.muster.kt.endpoints
+package com.muster.kt.endpoints.ministry.saveministry
 
-import com.muster.kt.model.Ministry
 import com.natpryce.hamkrest.assertion.assertThat
 import org.http4k.core.Status
 import org.http4k.hamkrest.hasBody

--- a/muster-kt/src/test/kotlin/com/muster/kt/endpoints/ministry/saveministry/MinistryServiceTest.kt
+++ b/muster-kt/src/test/kotlin/com/muster/kt/endpoints/ministry/saveministry/MinistryServiceTest.kt
@@ -1,4 +1,4 @@
-package com.muster.kt.endpoints
+package com.muster.kt.endpoints.ministry.saveministry
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo


### PR DESCRIPTION
Adding endpoint to save a ministry (in memory only).

Details:
- completed E2E endpoint with a in memory storage (Routes - Controller - Service, no repository yet)
-  used `Optional` instead of `null` everywhere 🎉 🥳 
- added a `Runtime` component where "DI" occurs at compile time 🎉 ✌️ 
- all tests.
- remove hello world code from main class (`Muster.kt`). Pushed it to all to its own `HelloWorld` classes.
- started to define a theoretical hierarchy or packages to group code by endpoint.
- start with endpoint versioning from inception.
- make the app run indefinitely, use port 8888.
- added some minimal documentation 💝 

part of #2 